### PR TITLE
Fix ResouceTab Filter

### DIFF
--- a/frontend/src/components/Admin/AdminDashboard.jsx
+++ b/frontend/src/components/Admin/AdminDashboard.jsx
@@ -15,7 +15,7 @@ export default function AdminDashboard() {
     pending: 0,
   });
   const [filters, setFilters] = useState({
-    status: "ALL",
+    status: "PENDING",
     subject: "",
     contributor: "",
     course: "",
@@ -24,8 +24,14 @@ export default function AdminDashboard() {
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(0);
   const [departments, setDepartments] = useState([]);
+  const [activeStatus, setActiveStatus] = useState("PENDING");
 
   const numberResourceDisplay = 5;
+
+  useEffect(() => {
+  updateCounts();
+}, []);
+
 
   useEffect(() => {
     fetchResources(page);
@@ -48,25 +54,35 @@ export default function AdminDashboard() {
     fetchCourses();
   }, []);
 
-  const fetchResources = async (page = 0) => {
+  const fetchResources = async (status = "PENDING", page = 0) => {
     setLoading(true);
     const from = page * numberResourceDisplay;
     const to = from + numberResourceDisplay - 1;
 
-    const { data, error } = await supabase
+    let query = supabase
       .from("resources")
       .select(
         `*, profiles!resources_uploader_profile_id_fkey(first_name, last_name, course, semester), subjects(name)`
       )
       .range(from, to);
 
+    if (status && status !== "ALL") {
+      query = query.eq("status", status);
+    }
+
+    const { data, error } = await query;
+
     if (error) {
       console.error("Error fetching resources:", error);
     } else {
-      setResources((prev) => [...prev, ...data]);
-      updateCounts();
+      // Reset or append based on page
+      setResources((prev) => (page === 0 ? data : [...prev, ...data]));
+      applyFilters(page === 0 ? data : [...resources, ...data], filters);
+
       if (data.length < numberResourceDisplay) {
         setHasMore(false);
+      } else {
+        setHasMore(true);
       }
     }
 
@@ -77,9 +93,18 @@ export default function AdminDashboard() {
     try {
       const [total, approved, rejected, pending] = await Promise.all([
         supabase.from("resources").select("*", { count: "exact", head: true }),
-        supabase.from("resources").select("*", { count: "exact", head: true }).eq("status", "APPROVED"),
-        supabase.from("resources").select("*", { count: "exact", head: true }).eq("status", "REJECTED"),
-        supabase.from("resources").select("*", { count: "exact", head: true }).eq("status", "PENDING"),
+        supabase
+          .from("resources")
+          .select("*", { count: "exact", head: true })
+          .eq("status", "APPROVED"),
+        supabase
+          .from("resources")
+          .select("*", { count: "exact", head: true })
+          .eq("status", "REJECTED"),
+        supabase
+          .from("resources")
+          .select("*", { count: "exact", head: true })
+          .eq("status", "PENDING"),
       ]);
 
       setCounts({
@@ -97,51 +122,85 @@ export default function AdminDashboard() {
     const filtered = data.filter((r) => {
       const matchesStatus = !status || status === "ALL" || r.status === status;
       const matchesSubject =
-        !subject || r.subjects?.name.toLowerCase().includes(subject.toLowerCase());
-      const fullName = `${r.profiles?.first_name || ""} ${r.profiles?.last_name || ""}`.toLowerCase();
-      const matchesContributor = !contributor || fullName.includes(contributor.toLowerCase());
-      const matchesCourse = !course || r.profiles?.course?.toLowerCase().includes(course.toLowerCase());
+        !subject ||
+        r.subjects?.name.toLowerCase().includes(subject.toLowerCase());
+      const fullName = `${r.profiles?.first_name || ""} ${
+        r.profiles?.last_name || ""
+      }`.toLowerCase();
+      const matchesContributor =
+        !contributor || fullName.includes(contributor.toLowerCase());
+      const matchesCourse =
+        !course ||
+        r.profiles?.course?.toLowerCase().includes(course.toLowerCase());
 
-      return matchesStatus && matchesSubject && matchesContributor && matchesCourse;
+      return (
+        matchesStatus && matchesSubject && matchesContributor && matchesCourse
+      );
     });
 
     setFiltered(filtered);
   };
 
-  const handleFilterChange = (newFilters) => {
-    setFilters(newFilters);
+  // const handleFilterChange = (newFilters) => {
+  //   setFilters(newFilters);
+  //   applyFilters(resources, newFilters);
+  // };
+
+  const handleStatusChange = (status) => {
+    setActiveStatus(status);
+    setPage(0);
+    setResources([]);
+    fetchResources(status, 0);
   };
 
   const handleAction = async () => {
     setPage(0);
     setResources([]);
-    await fetchResources(0);
+    await fetchResources(activeStatus, 0);
+    await updateCounts();
   };
 
   const loadMoreResources = () => {
-    setPage((prev) => prev + 1);
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchResources(activeStatus, nextPage);
   };
 
   return (
     <div className="min-h-screen bg-[#FFFEFE] p-4 md:p-8">
       <div className="max-w-7xl mx-auto space-y-8">
         <Heading />
-        <StatusSummary counts={counts} onStatusClick={() => {}} />
+        <StatusSummary counts={counts} onStatusClick={handleStatusChange} />
 
         <div className="bg-white rounded-md border-2 border-gray-300 shadow-[7px_8px_4.8px_rgba(0,0,0,0.1)] mt-8">
           {/* Header */}
           <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
-            <svg className="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m2 0a2 2 0 002-2V6a2 2 0 00-2-2H7a2 2 0 00-2 2v4a2 2 0 002 2m10 0v6a2 2 0 01-2 2H7a2 2 0 01-2-2v-6" />
+            <svg
+              className="w-6 h-6 text-gray-700"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 12h6m2 0a2 2 0 002-2V6a2 2 0 00-2-2H7a2 2 0 00-2 2v4a2 2 0 002 2m10 0v6a2 2 0 01-2 2H7a2 2 0 01-2-2v-6"
+              />
             </svg>
-            <h2 className="text-xl font-bold text-gray-800">Submitted Resources</h2>
+            <h2 className="text-xl font-bold text-gray-800">
+              Submitted Resources
+            </h2>
           </div>
 
-          {/* Collapsible Filter */}
           <div className="p-6">
             <ResourceFilter
-              filters={filters}
-              onChange={handleFilterChange}
+              filters={{ ...filters, status: activeStatus }}
+              onChange={(newFilters) => {
+                setFilters(newFilters);
+                applyFilters(resources, newFilters);
+              }}
+              onStatusChange={handleStatusChange}
               departments={departments}
             />
           </div>
@@ -158,12 +217,28 @@ export default function AdminDashboard() {
               <div className="p-6">
                 <div className="border border-dashed border-gray-300 p-10 rounded-xl text-center bg-white/90 backdrop-blur-sm shadow">
                   <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gray-100 mb-4">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-8 w-8 text-gray-400"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
                     </svg>
                   </div>
-                  <p className="text-xl font-semibold text-gray-700 mb-2">No resources found</p>
-                  <p className="text-gray-500 max-w-md mx-auto">Try changing the filters or check back later when new resources are submitted.</p>
+                  <p className="text-xl font-semibold text-gray-700 mb-2">
+                    No resources found
+                  </p>
+                  <p className="text-gray-500 max-w-md mx-auto">
+                    Try changing the filters or check back later when new
+                    resources are submitted.
+                  </p>
                 </div>
               </div>
             ) : (
@@ -175,7 +250,11 @@ export default function AdminDashboard() {
                       return priority[a.status] - priority[b.status];
                     })
                     .map((resource) => (
-                      <ResourceCard key={resource.id} resource={resource} onAction={handleAction} />
+                      <ResourceCard
+                        key={resource.id}
+                        resource={resource}
+                        onAction={handleAction}
+                      />
                     ))}
                 </div>
                 {hasMore && (
@@ -197,4 +276,3 @@ export default function AdminDashboard() {
     </div>
   );
 }
-

--- a/frontend/src/components/Admin/ResourceCard.jsx
+++ b/frontend/src/components/Admin/ResourceCard.jsx
@@ -188,7 +188,7 @@ export default function ResourceCard({ resource, onAction }) {
         return null;
     }
   };
-  if (!resource || resource.status === "REJECTED") return null;
+  // if (!resource || resource.status === "REJECTED") return null;
 
   return (
     <div className="border-2 border-gray-300 rounded-md p-3 sm:p-4 hover:shadow-[7px_8px_4.8px_rgba(0,0,0,0.1)] bg-white">

--- a/frontend/src/components/Admin/ResourceFilter.jsx
+++ b/frontend/src/components/Admin/ResourceFilter.jsx
@@ -8,7 +8,7 @@ const { Option } = Select;
 
 const statusTabs = ["ALL", "PENDING", "APPROVED", "REJECTED"];
 
-export default function ResourceFilter({ filters, onChange, departments }) {
+export default function ResourceFilter({ filters, onChange, departments, onStatusChange }) {
   const [subject, setSubject] = useState(filters.subject || "");
   const [contributor, setContributor] = useState(filters.contributor || "");
   const [course, setCourse] = useState(filters.course || "");
@@ -45,6 +45,7 @@ export default function ResourceFilter({ filters, onChange, departments }) {
       ...filters,
       status: status === "ALL" ? "" : status,
     });
+    if (onStatusChange) onStatusChange(status);
   };
 
   return (
@@ -81,7 +82,7 @@ export default function ResourceFilter({ filters, onChange, departments }) {
       <div className={`transition-all duration-300 ease-in-out ${isExpanded ? "max-h-[800px] opacity-100" : "max-h-0 opacity-0 overflow-hidden"}`}>
         
         {/* Tabs */}
-        <div className="px-4 pt-4 grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
+        <div className="px-4 pt-4 grid grid-cols-2 sm:flex sm:flex-wrap gap-2 ">
           {statusTabs.map((tab) => (
             <button
               key={tab}
@@ -109,7 +110,7 @@ export default function ResourceFilter({ filters, onChange, departments }) {
               placeholder="Search subjects..."
               prefix={<SearchOutlined className="text-gray-400" />}
               size="middle"
-              className="w-full"
+              className="w-full custom-input"
             />
           </div>
 
@@ -123,7 +124,7 @@ export default function ResourceFilter({ filters, onChange, departments }) {
               placeholder="Contributor name"
               prefix={<UserOutlined className="text-gray-400" />}
               size="middle"
-              className="w-full"
+              className="w-full custom-input"
             />
           </div>
 
@@ -135,7 +136,7 @@ export default function ResourceFilter({ filters, onChange, departments }) {
               onChange={(value) => setCourse(value)}
               allowClear
               placeholder="All Programs"
-              className="w-full"
+              className="w-full custom-select"
               size="middle"
               popupMatchSelectWidth={false}
               showSearch


### PR DESCRIPTION

**Fix Resource Tab Filter with Pagination Support**

#### 📌 **Summary**

This PR improves the `AdminDashboard` by fixing the filtering logic on resource status (PENDING, APPROVED, REJECTED) tabs. The previous implementation only applied filters to already fetched resources, causing inaccurate results when paginating. Now, each status tab fetches its own data directly from Supabase with proper pagination.

---

#### ✅ **What’s Fixed / Changed**

* Implemented server-side fetching of resources **by status** (`PENDING`, `APPROVED`, `REJECTED`, `ALL`) using Supabase filters.
* Added a new state `activeStatus` to track the currently selected tab.
* Refactored `fetchResources(status, page)` to dynamically fetch paginated resources based on selected status.
* Fixed broken `StatusSummary` counts by ensuring `updateCounts()` is called on initial load and after resource actions (e.g., approval/rejection).
* `handleAction` now refreshes resources and updates summary counts post any admin operation.